### PR TITLE
Add Group visibility and Playback/Playlist Access Control to SyncPlay 

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -3394,6 +3394,20 @@ class ApiClient {
     }
 
     /**
+     * Gets a list of all the users that have access to SyncPlay.
+     * @returns {Promise} A Promise that resolves to the list of available users.
+     * @since 10.7.0
+     */
+    getAvailableSyncPlayUsers() {
+        const url = this.getUrl(`SyncPlay/ListAvailableUsers`);
+
+        return this.ajax({
+            type: 'GET',
+            url: url
+        });
+    }
+
+    /**
      * Creates a SyncPlay group on the server with the current client as member.
      * @param {object} options Settings for the SyncPlay group to create.
      * @returns {Promise} A Promise fulfilled upon request completion.
@@ -3438,6 +3452,23 @@ class ApiClient {
         return this.ajax({
             type: 'POST',
             url: url
+        });
+    }
+
+    /**
+     * Updates the settings of the SyncPlay group.
+     * @param {object} options Settings to set.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    updateSyncPlayGroupSettings(options = {}) {
+        const url = this.getUrl(`SyncPlay/Settings`);
+
+        return this.ajax({
+            type: 'POST',
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 


### PR DESCRIPTION
**Changes**
Add SyncPlay group settings endpoint.

This PR is related to the [server side one](https://github.com/jellyfin/jellyfin/pull/4717).