### PR TITLE
Add SystemInfo to connect result

### DIFF
--- a/src/connectionManager.js
+++ b/src/connectionManager.js
@@ -731,6 +731,7 @@ export default class ConnectionManager {
             result.ApiClient = self._getOrAddApiClient(server, serverUrl);
 
             result.ApiClient.setSystemInfo(systemInfo);
+            result.SystemInfo = systemInfo;
 
             result.State = server.AccessToken && options.enableAutoLogin !== false ? 'SignedIn' : 'ServerSignIn';
 


### PR DESCRIPTION
Adds the SystemInfo response to the connect response. This should allow us to cut out some duplicate API calls at app startup.