### PR TITLE
Fix authentication with bad credentials

### DIFF
--- a/src/connectionManager.js
+++ b/src/connectionManager.js
@@ -751,9 +751,12 @@ export default class ConnectionManager {
             if (result.State === 'SignedIn') {
                 afterConnected(result.ApiClient, options);
 
-                result.ApiClient.getCurrentUser().then((user) => {
-                    onLocalUserSignIn(server, serverUrl, user).then(resolveActions, resolveActions);
-                }, resolveActions);
+                result.ApiClient.getCurrentUser()
+                    .then((user) => {
+                        return onLocalUserSignIn(server, serverUrl, user);
+                    })
+                    .then(resolveActions)
+                    .catch(resolveActions);
             } else {
                 resolveActions();
             }

--- a/src/connectionManager.js
+++ b/src/connectionManager.js
@@ -732,7 +732,7 @@ export default class ConnectionManager {
 
             result.ApiClient.setSystemInfo(systemInfo);
 
-            result.State = server.AccessToken && options.enableAutoLogin !== false ? 'SignedIn' : 'ServerSignIn';
+            result.State = 'ServerSignIn';
 
             result.Servers.push(server);
 
@@ -748,14 +748,17 @@ export default class ConnectionManager {
                 events.trigger(self, 'connected', [result]);
             };
 
-            if (result.State === 'SignedIn') {
+            if (server.AccessToken && options.enableAutoLogin !== false) {
                 afterConnected(result.ApiClient, options);
 
                 result.ApiClient.getCurrentUser()
                     .then((user) => {
                         return onLocalUserSignIn(server, serverUrl, user);
                     })
-                    .then(resolveActions)
+                    .then(() => {
+                        result.State = 'SignedIn';
+                        resolveActions();
+                    })
                     .catch(resolveActions);
             } else {
                 resolveActions();


### PR DESCRIPTION
**Changes**
- Line up Promises.
- Fix connection state when could not authenticate.
The connection state remains `SignedIn` even if the user has logged out (token expired) or doesn't exist.