### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 </a>
 </p>
 
+> [!WARNING]
+> This library is **deprecated**.
+> It is recommended to use the [TypeScript SDK](https://github.com/jellyfin/jellyfin-sdk-typescript) instead.
+> No future releases are planned and no new features will be supported.
+
 This library is meant to help clients written in JavaScript interact with Jellyfin's REST API.
 
 ## Compatibility


### PR DESCRIPTION
Adds a deprecation notice to the README to point people to the TS SDK instead.